### PR TITLE
feat: Enable multiple API key profiles for message summarization

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -85,6 +85,13 @@
 
                 <hr>
 
+                <!-- API Key Management -->
+                <h4 class="textAlignCenter">API Key Management <i class="fa-solid fa-info-circle" title="Manage API keys for external services."></i></h4>
+                <label for="api_keys_input">Paste your API keys below, one per line:</label>
+                <textarea id="api_keys_input" class="text_pole" rows="4" placeholder="Enter API keys here..."></textarea>
+
+                <hr>
+
                 <label class="checkbox_label" title="New messages will be automatically summarized if they will be included in short-term memory.">
                     <input id="auto_summarize" type="checkbox" />
                     <span>Auto Summarize</span>


### PR DESCRIPTION
This change allows you to specify multiple connection profiles (acting as API keys) for summarizing messages in batches.

Key changes:
- Added a textarea in settings.html for you to input a list of connection profile names.
- Modified index.js to read these profile names.
- The `summarize_messages` function now accepts a list of profile names and cycles through them for each message in a batch.
- If no profiles are provided in the new UI, the system falls back to the connection profile specified in the extension's general settings.
- Implemented storage for the list of profile names you provide, so they persist across sessions.
- Added robust error handling:
    - Validates connection profile names before use.
    - Catches errors during profile setup and individual message summarization.
    - Displays specific error messages in the UI for affected messages.
    - Ensures the original SillyTavern connection profile is restored after batch processing, regardless of errors.
- Updated UI bindings to save and load the list of profile names.